### PR TITLE
Function doesn't handle inactive final components

### DIFF
--- a/modules/publix/app/assets/javascripts/jatos.js
+++ b/modules/publix/app/assets/javascripts/jatos.js
@@ -1334,18 +1334,6 @@ var jatos = {};
 			onError = param2;
 		}
 
-		// If last component end study
-		if (jatos.componentPos >= jatos.componentList.length) {
-			if (resultData) {
-				var onComplete = function () {
-					jatos.endStudy(true, message);
-				};
-				jatos.appendResultData(resultData).done(onComplete).fail(onError);
-			} else {
-				jatos.endStudy(true, message);
-			}
-			return;
-		}
 		for (var i = jatos.componentPos; i < jatos.componentList.length; i++) {
 			if (jatos.componentList[i].active) {
 				var nextComponentId = jatos.componentList[i].id;
@@ -1353,6 +1341,16 @@ var jatos = {};
 				break;
 			}
 		}
+		// If last component end study
+		if (resultData) {
+			var onComplete = function () {
+				jatos.endStudy(true, message);
+			};
+			jatos.appendResultData(resultData).done(onComplete).fail(onError);
+		} else {
+			jatos.endStudy(true, message);
+		}
+		return;
 	};
 
 	/**

--- a/modules/publix/app/assets/javascripts/jatos.js
+++ b/modules/publix/app/assets/javascripts/jatos.js
@@ -1338,9 +1338,10 @@ var jatos = {};
 			if (jatos.componentList[i].active) {
 				var nextComponentId = jatos.componentList[i].id;
 				jatos.startComponent(nextComponentId, resultData, param2, param3);
-				break;
+				return;
 			}
 		}
+		
 		// If last component end study
 		if (resultData) {
 			var onComplete = function () {


### PR DESCRIPTION
Originally, if your component had inactive components following it, it would not `endStudy()` like I would expect. This change moves the endstudy bit after the check for active components. This means if there are no active components to go to *then* it would end the study.