### PR TITLE
 ZipUtil.java - check for path traversal attack

### DIFF
--- a/modules/common/app/utils/common/ZipUtil.java
+++ b/modules/common/app/utils/common/ZipUtil.java
@@ -48,6 +48,10 @@ public class ZipUtil {
             ZipEntry zipEntry = (ZipEntry) zipEnumeration.nextElement();
             String fileName = zipEntry.getName();
             file = new File(destDir, fileName);
+            String canonicalPath = file.getCanonicalPath();
+            if (!canonicalPath.startsWith(destDir.getCanonicalPath() + File.separator)) {
+                throw new IOException("Illegal name: " + fileName);
+            }
             if (fileName.endsWith(ZIP_FILE_SEPARATOR)) {
                 file.mkdirs();
                 continue;


### PR DESCRIPTION
Refering to https://github.com/JATOS/JATOS/commit/2b42519f309d8164e8811392770ce604cdabb5da
also the fileName parameter should be checked for path traversal attacks 
---------