### PR TITLE
git commit -m "Fix: loader.bat - Replaced WMIC with tasklist for proc…

### DIFF
--- a/loader.bat
+++ b/loader.bat
@@ -50,7 +50,7 @@ rem ### Functions ###
 
 :start
   rem # Check if JATOS is already running
-  wmic process where "name like '%%java%%'" get commandline | findstr /i /c:"jatos" > NUL && (
+  tasklist /nh /fi "imagename eq java.exe" /v | findstr /i /c:"jatos" > NUL && (
     echo JATOS already running
     if _%DOUBLECLICKED%_==_1_ pause
     goto:eof


### PR DESCRIPTION
This pull request addresses an issue where `loader.bat` might fail to run on Windows 11 systems due to the deprecation and removal of `WMIC` (Windows Management Instrumentation Command-line) by default.

The original script used `wmic process where "name like '%%java%%'" get commandline` to check if JATOS was already running. This change replaces the `wmic` command with `tasklist /nh /fi "imagename eq java.exe" /v`, which achieves the same goal without relying on `WMIC`.

This ensures `loader.bat` functions correctly on Windows 11 out-of-the-box and avoids the need for users to manually install `WMIC` as an optional feature.