### PR TITLE
fix: correct Windows path separator handling for study import on Windows

### DIFF
--- a/modules/common/app/models/common/Component.java
+++ b/modules/common/app/models/common/Component.java
@@ -141,11 +141,7 @@ public class Component {
     }
 
     public String getHtmlFilePath() {
-        if (htmlFilePath != null) {
-            return this.htmlFilePath.replace('/', File.separatorChar);
-        } else {
-            return null;
-        }
+        return this.htmlFilePath;
     }
 
     public void setComments(String comments) {

--- a/modules/common/app/utils/common/IOUtils.java
+++ b/modules/common/app/utils/common/IOUtils.java
@@ -34,10 +34,10 @@ public class IOUtils {
     public static final String REGEX_ILLEGAL_IN_FILENAME = "[\\s\\n\\r\\t\\f*?\"\\\\\0/,`<>|:~!§$%&^°]";
 
     /*
-     * No spaces, no nulls, must start with '/'
+     * No spaces, no nulls
      */
 //    public static final String REGEX_ILLEGAL_IN_PATH = "[^/([^ \\x00/]+/?)+$]";
-    public static final String REGEX_ILLEGAL_IN_PATH = "^/[^\\x00\\s]*$";
+    public static final String REGEX_ILLEGAL_IN_PATH = "^[^\\x00\\s]+$";
 
     private static final int MAX_FILENAME_LENGTH = 100;
 

--- a/modules/gui/test/services/gui/ComponentServiceTest.java
+++ b/modules/gui/test/services/gui/ComponentServiceTest.java
@@ -87,7 +87,7 @@ public class ComponentServiceTest {
         // same fields
         assertThat(clone.getStudy()).isEqualTo(s);
         assertThat(clone.getTitle()).isEqualTo("Comp A");
-        assertThat(clone.getHtmlFilePath()).isEqualTo("a" + File.separator + "index.html");
+        assertThat(clone.getHtmlFilePath()).isEqualTo("a/index.html");
         assertThat(clone.isReloadable()).isTrue();
         assertThat(clone.isActive()).isTrue();
         assertThat(clone.getComponentInput()).isEqualTo("{\"x\":1}");


### PR DESCRIPTION
## Summary

Fixes two Windows-specific path separator bugs that prevent study import on Windows
in JATOS 3.10.1 when the study was originally exported from a Linux instance.

Fixes #339

## Changes

### 1. `Component.java` — Remove premature path separator conversion in `getHtmlFilePath()`

The getter was converting `/` to `File.separatorChar` (i.e., `\` on Windows) before
returning. When `ComponentService.bindToProperties()` passed this value to the
validator, the validator received backslash paths and rejected them with:

> "Not a valid path or filename. Remember to use '/' as folder separator."

The fix removes the conversion from the getter. The stored format always uses forward
slashes, and that is what the getter should return. Separator conversion should only
occur when constructing filesystem `File` objects for actual I/O — not in a getter
whose return value is also used for validation.

The existing `clone_shouldCopyFields_andGenerateNewUuid` test in `ComponentServiceTest`
was updated accordingly, as its assertion had been written to match the old behavior.

### 2. `IOUtils.java` — Cross-platform `REGEX_ILLEGAL_IN_PATH`

The constant `REGEX_ILLEGAL_IN_PATH = "^/[^\x00\s]*$"` required paths to begin with
`/`. This is valid for Unix absolute paths but rejects all Windows absolute paths,
which begin with a drive letter (e.g., `D:\`).

The fix uses `"^[^\x00\s]+$"`, which enforces the actual intent — paths must be
non-empty and contain no null bytes or whitespace — without any platform-specific
assumption.

## Testing

I verified these fixes by applying equivalent changes at the bytecode level to the
compiled JAR in a live JATOS 3.10.1 Windows deployment and confirming that study
import succeeds end-to-end. I do not have a local Java/sbt build environment to run
the full test suite — happy to address any CI failures that arise.
